### PR TITLE
Update setup.py to 0.0.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/instabase/flow-parser',
-    version='0.0.2',
+    version='0.0.3',
     zip_safe=False,
 )


### PR DESCRIPTION
Right now setup.py still reads as 0.0.2 meaning that pip install is still installing 0.0.2 (or it's still logging it as 0.0.2 even if it may be the newer version)